### PR TITLE
fix ClassCastException in getParameters() when a build had parameters that weren't strings

### DIFF
--- a/src/main/java/com/offbytwo/jenkins/model/BuildWithDetails.java
+++ b/src/main/java/com/offbytwo/jenkins/model/BuildWithDetails.java
@@ -113,10 +113,10 @@ public class BuildWithDetails extends Build {
         Map<String, String> params = new HashMap<String, String>();
 
         if (parameters != null && !parameters.isEmpty()) {
-            for (Map<String, String> param : ((Map<String, List<Map<String, String>>>) parameters.toArray()[0]).get("parameters")) {
-                String key = param.get("name");
-                String value = param.get("value");
-                params.put(key, value);
+            for (Map<String, Object> param : ((Map<String, List<Map<String, Object>>>) parameters.toArray()[0]).get("parameters")) {
+                String key = (String) param.get("name");
+                Object value = param.get("value");
+                params.put(key, String.valueOf(value));
             }
         }
 

--- a/src/test/java/com/offbytwo/jenkins/integration/JenkinsServerIntegrationTest.java
+++ b/src/test/java/com/offbytwo/jenkins/integration/JenkinsServerIntegrationTest.java
@@ -12,6 +12,7 @@ import com.offbytwo.jenkins.model.BuildWithDetails;
 import com.offbytwo.jenkins.model.Computer;
 import com.offbytwo.jenkins.model.Job;
 import com.offbytwo.jenkins.model.JobWithDetails;
+import hudson.model.BooleanParameterValue;
 import hudson.model.Cause;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParametersAction;
@@ -77,6 +78,19 @@ public class JenkinsServerIntegrationTest {
         BuildWithDetails build = job.getBuilds().get(0).details();
         assertEquals(BuildResult.SUCCESS, build.getResult());
         assertEquals("foobar", build.getParameters().get("REVISION"));
+    }
+
+    @Test
+    public void shouldSupportBooleanParameters() throws Exception {
+        FreeStyleProject pr = jenkinsRule.getInstance().createProject(FreeStyleProject.class, JENKINS_TEST_JOB);
+        pr.scheduleBuild(0, new Cause.UserCause(), new ParametersAction(new BooleanParameterValue("someValue", true)));
+
+        while (pr.isInQueue() || pr.isBuilding()) {
+        }
+
+        JobWithDetails job = server.getJobs().get(JENKINS_TEST_JOB).details();
+        BuildWithDetails build = job.getBuilds().get(0).details();
+        assertEquals("true", build.getParameters().get("someValue"));
     }
 
     @Test


### PR DESCRIPTION
`BuildWithDetails.getParameters` throws a ClassCastException when the build contains parameter-values that aren't Strings (e.g. `true` and `false`). 

This pull request fixes this and instead returns the `toString` of all parameter values. Might not be the most type-safe solution but I didn't want to introduce API breaking changes in a pull request. 