### PR TITLE
URL encoding method is invalid for non-standard job and node names

### DIFF
--- a/src/main/java/com/offbytwo/jenkins/JenkinsServer.java
+++ b/src/main/java/com/offbytwo/jenkins/JenkinsServer.java
@@ -8,6 +8,7 @@ package com.offbytwo.jenkins;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Maps;
+import com.google.common.net.UrlEscapers;
 import com.offbytwo.jenkins.client.JenkinsHttpClient;
 import com.offbytwo.jenkins.model.Computer;
 import com.offbytwo.jenkins.model.Job;
@@ -23,7 +24,6 @@ import org.dom4j.DocumentException;
 import javax.xml.bind.JAXBException;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URLEncoder;
 import java.util.List;
 import java.util.Map;
 
@@ -164,11 +164,11 @@ public class JenkinsServer {
      * @throws IOException
      */
     public void createJob(String jobName, String jobXml) throws IOException {
-        client.post_xml("/createItem?name=" + encode(jobName), jobXml);
+        client.post_xml("/createItem?name=" + encodeParam(jobName), jobXml);
     }
     
     public void createJob(String jobName, String jobXml, Boolean crumbFlag) throws IOException {
-        client.post_xml("/createItem?name=" + encode(jobName), jobXml, crumbFlag);
+        client.post_xml("/createItem?name=" + encodeParam(jobName), jobXml, crumbFlag);
     }
 
     /**
@@ -269,6 +269,12 @@ public class JenkinsServer {
 
     private String encode(String pathPart) {
         // jenkins doesn't like the + for space, use %20 instead
-        return URLEncoder.encode(pathPart).replaceAll("\\+", "%20");
+        String escape = UrlEscapers.urlPathSegmentEscaper().escape(pathPart);
+        return escape;
+    }
+
+    private String encodeParam(String pathPart) {
+        // jenkins doesn't like the + for space, use %20 instead
+        return UrlEscapers.urlFormParameterEscaper().escape(pathPart);
     }
 }

--- a/src/main/java/com/offbytwo/jenkins/model/Computer.java
+++ b/src/main/java/com/offbytwo/jenkins/model/Computer.java
@@ -7,14 +7,13 @@
 package com.offbytwo.jenkins.model;
 
 import com.google.common.base.Function;
-import com.google.common.collect.Collections2;
+import com.google.common.escape.Escaper;
+import com.google.common.net.UrlEscapers;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import static java.net.URLEncoder.encode;
-import static org.apache.commons.lang.StringUtils.join;
 
 public class Computer extends BaseModel {
 
@@ -42,7 +41,14 @@ public class Computer extends BaseModel {
     }
 
     public ComputerWithDetails details() throws IOException {
-        return client.get("/computer/" + displayName.replaceAll("master", "(master)"), ComputerWithDetails.class);
+        String name;
+        if ("master".equals(displayName)) {
+            name = "(master)";
+        }
+        else {
+            name = UrlEscapers.urlPathSegmentEscaper().escape(displayName);
+        }
+        return client.get("/computer/" + name, ComputerWithDetails.class);
     }
 
     @Override
@@ -70,7 +76,8 @@ public class Computer extends BaseModel {
     private static class MapEntryToQueryStringPair implements Function<Map.Entry<String, String>, String> {
         @Override
         public String apply(Map.Entry<String, String> entry) {
-            return encode(entry.getKey()) + "=" + encode(entry.getValue());
+            Escaper escaper = UrlEscapers.urlFormParameterEscaper();
+            return escaper.escape(entry.getKey()) + "=" + escaper.escape(entry.getValue());
         }
     }
 }

--- a/src/main/java/com/offbytwo/jenkins/model/Job.java
+++ b/src/main/java/com/offbytwo/jenkins/model/Job.java
@@ -8,11 +8,12 @@ package com.offbytwo.jenkins.model;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
+import com.google.common.escape.Escaper;
+import com.google.common.net.UrlEscapers;
 
 import java.io.IOException;
 import java.util.Map;
 
-import static java.net.URLEncoder.encode;
 import static org.apache.commons.lang.StringUtils.join;
 
 public class Job extends BaseModel {
@@ -86,7 +87,8 @@ public class Job extends BaseModel {
     private static class MapEntryToQueryStringPair implements Function<Map.Entry<String, String>, String> {
         @Override
         public String apply(Map.Entry<String, String> entry) {
-            return encode(entry.getKey()) + "=" + encode(entry.getValue());
+            Escaper escaper = UrlEscapers.urlFormParameterEscaper();
+            return escaper.escape(entry.getKey()) + "=" + escaper.escape(entry.getValue());
         }
     }
 }

--- a/src/test/java/com/offbytwo/jenkins/JenkinsServerTest.java
+++ b/src/test/java/com/offbytwo/jenkins/JenkinsServerTest.java
@@ -115,4 +115,11 @@ public class JenkinsServerTest extends BaseUnitTest {
         server.quietDown();
         server.cancelQuietDown();
     }
+
+    @Test
+    public void testJenkinsPathEncoding() throws IOException {
+        given(client.get("/job/encoded%2Fproperly%3F/config.xml")).willReturn("<xml>not a real response</xml>");
+
+        assertEquals("<xml>not a real response</xml>", server.getJobXml("encoded/properly?"));
+    }
 }


### PR DESCRIPTION
The JenkinsClient uses java.net.URLEncoder to encode path segments as if they were parameter names or values. This can lead to invalid URLs to which the Jenkins server responds with errors.

Additionally, the method used depends on the client JDKs current default encoding to encode values. Jenkins requires URLs to be encoded as UTF-8, and does not handle non-english otherwise.

And finally: If a build-node name contained "master" anywhere in its name, the client would illegally mangle the name while building the URL. Thus a node name like "evil-master-mind" turns into "evil-(master)-mind" and jenkins no longer recognizes the node name.

This patch simply splits the encoding of path segments from the encoding of parameter names and values and uses the correct Guava UrlEscaper for each case.