### PR TITLE
Add API method for deleting jobs without crumbs enabled.

### DIFF
--- a/src/main/java/com/offbytwo/jenkins/JenkinsServer.java
+++ b/src/main/java/com/offbytwo/jenkins/JenkinsServer.java
@@ -269,6 +269,10 @@ public class JenkinsServer {
         client.post("/job/" + encode(jobName) + "/doDelete");
     }
 
+    public void deleteJob(String jobName, boolean crumbFlag) throws IOException {
+        client.post("/job/" + encode(jobName) + "/doDelete", crumbFlag);
+    }
+
     /**
      * Runs the provided groovy script on the server and returns the result.
      *


### PR DESCRIPTION
There is currently no way to delete jobs from a Jenkins server that does
not have the crumbIssuer enabled. This method adds that functionality.

Fixes #56 