### PR TITLE
- Reduced pom configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <targetJdk>1.6</targetJdk>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
 
         <!-- Version of Jenkins to use for Integration Tests -->
         <jenkins-version>1.593</jenkins-version>
@@ -142,12 +143,22 @@
     </dependencies>
 
     <build>
-        <plugins>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.18.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.18.1</version>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
-                <inherited>true</inherited>
+                <version>2.6</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -157,47 +168,24 @@
                     </archive>
                 </configuration>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.0</version>
-                <configuration>
-                    <source>${targetJdk}</source>
-                    <target>${targetJdk}</target>
-                </configuration>
+                <version>3.3</version>
             </plugin>
-
+          </plugins>
+        </pluginManagement>
+        <plugins>
+            <!--
+              ! Bind it to the life cycle.
+            -->
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <includes>
-                        <include>**/*Test.java</include>
-                    </includes>
-                    <excludes>
-                        <exclude>**/*IntegrationTest.java</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <includes>
-                        <include>**/*IntegrationTest.java</include>
-                    </includes>
-                </configuration>
                 <executions>
                     <execution>
                         <id>integration-test</id>
                         <goals>
                             <goal>integration-test</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>verify</id>
-                        <goals>
                             <goal>verify</goal>
                         </goals>
                     </execution>

--- a/src/test/java/com/offbytwo/jenkins/integration/BaseForIntegrationTests.java
+++ b/src/test/java/com/offbytwo/jenkins/integration/BaseForIntegrationTests.java
@@ -5,7 +5,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.jvnet.hudson.test.JenkinsRule;
 
-public class BaseIntegrationTest {
+public class BaseForIntegrationTests {
 
     @Rule
     public JenkinsRule jenkinsRule = new JenkinsRule();

--- a/src/test/java/com/offbytwo/jenkins/integration/JenkinsClientIT.java
+++ b/src/test/java/com/offbytwo/jenkins/integration/JenkinsClientIT.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 
 import static org.junit.Assert.assertNotNull;
 
-public class JenkinsClientIntegrationTest extends BaseIntegrationTest {
+public class JenkinsClientIT extends BaseForIntegrationTests {
 
     public static final String TEST_CREATE_JOB = "TestCreateJob";
 

--- a/src/test/java/com/offbytwo/jenkins/integration/JenkinsClientViewIT.java
+++ b/src/test/java/com/offbytwo/jenkins/integration/JenkinsClientViewIT.java
@@ -17,7 +17,7 @@ import java.util.Collection;
 
 import static org.junit.Assert.assertNotNull;
 
-public class JenkinsClientViewIntegrationTest extends BaseIntegrationTest {
+public class JenkinsClientViewIT extends BaseForIntegrationTests {
 
     public static final String TEST_VIEW = "testView";
 

--- a/src/test/java/com/offbytwo/jenkins/integration/JenkinsServerIT.java
+++ b/src/test/java/com/offbytwo/jenkins/integration/JenkinsServerIT.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-public class JenkinsServerIntegrationTest {
+public class JenkinsServerIT {
 
     @Rule
     public JenkinsRule jenkinsRule = new JenkinsRule();

--- a/src/test/java/com/offbytwo/jenkins/integration/JobConfigurationIT.java
+++ b/src/test/java/com/offbytwo/jenkins/integration/JobConfigurationIT.java
@@ -11,7 +11,7 @@ import java.net.URISyntaxException;
 
 import static org.junit.Assert.assertTrue;
 
-public class JobConfigurationIntegrationTest extends BaseIntegrationTest {
+public class JobConfigurationIT extends BaseForIntegrationTests {
 
     public static final String TEST_JOB = "TestCreateJob";
     public static final String TEST_PARA = "testPara";


### PR DESCRIPTION
By following naming conventions for maven-surefire-plugin and maven-failsafe-plugin.
Correctly defining the plugin version which prevents appropriate WARNINGs during the maven build.
Update maven-jar-plugin to non ancient version.