### PR TITLE
Added site generation which

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,6 @@
     <groupId>com.offbytwo.jenkins</groupId>
     <artifactId>jenkins-client</artifactId>
     <version>0.3.1-SNAPSHOT</version>
-    <packaging>jar</packaging>
 
     <parent>
         <groupId>org.sonatype.oss</groupId>
@@ -28,6 +27,12 @@
         <developerConnection>scm:git:git@github.com:RisingOak/jenkins-client.git</developerConnection>
         <url>https://github.com/RisingOak/jenkins-client</url>
     </scm>
+    <distributionManagement>
+      <site>
+        <id>github</id>
+        <url>scm:git:git@github.com:RisingOak/jenkins-client.git</url>
+      </site>
+    </distributionManagement>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -146,6 +151,22 @@
         <pluginManagement>
           <plugins>
             <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-source-plugin</artifactId>
+              <version>2.4</version>
+              <executions>
+                <!-- 
+                  ! here we override the super-pom attach-sources execution id which 
+                  ! calls sources:jar goal. That goals forks the lifecycle, 
+                  ! causing the generate-sources phase to be called twice for the install goal.
+                -->
+                <execution>
+                  <id>attach-sources</id>
+                  <phase>DISABLE_FORKED_LIFECYCLE_MSOURCES-13</phase>
+                </execution>
+              </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.18.1</version>
@@ -173,6 +194,22 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
             </plugin>
+            <!--
+               ! The gpg plugin is already defined in oss-parent
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.5</version>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-scm-publish-plugin</artifactId>
+              <version>1.1</version>
+              <configuration>
+                <scmBranch>gh-pages</scmBranch>
+              </configuration>
+            </plugin>
           </plugins>
         </pluginManagement>
         <plugins>
@@ -195,21 +232,47 @@
     </build>
 
     <reporting>
-        <plugins>
+      <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-report-plugin</artifactId>
+            <version>2.18.1</version>
+            <reportSets>
+              <reportSet>
+                <reports>
+                  <report>failsafe-report-only</report>
+                  <report>report</report>
+                </reports>
+              </reportSet>
+            </reportSets>
+          </plugin>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-project-info-reports-plugin</artifactId>
+              <version>2.8</version>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
-                <version>2.7.1</version>
+                <version>3.5</version>
+                <configuration>
+                  <targetJdk>${maven.compiler.target}</targetJdk>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.5.2</version>
+                <version>2.7</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
                 <version>2.5.2</version>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-jxr-plugin</artifactId>
+              <version>2.5</version>
             </plugin>
         </plugins>
     </reporting>
@@ -225,24 +288,23 @@
             </activation>
             <build>
                 <plugins>
+                    <!-- MSOURCES-13 related workaround overriding super-pom -->
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <version>2.2.1</version>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
+                      <inherited>true</inherited>
+                      <artifactId>maven-source-plugin</artifactId>
+                      <executions>
+                        <execution>
+                          <id>attach-sources-no-fork</id>
+                          <goals>
+                            <goal>jar-no-fork</goal>
+                          </goals>
+                        </execution>
+                      </executions>
                     </plugin>
-
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.9</version>
+                        <version>2.10.3</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -252,11 +314,10 @@
                             </execution>
                         </executions>
                     </plugin>
-
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.4</version>
+                        <version>1.5</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/DECORATION/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.0.0 http://maven.apache.org/xsd/decoration-1.0.0.xsd">
+
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>1.4</version>
+  </skin>
+
+  <custom>
+    <fluidoSkin>
+      <topBarEnabled>true</topBarEnabled>
+      <sideBarEnabled>true</sideBarEnabled>
+      <googleSearch>
+        <sitesearch>${project.url}</sitesearch>
+      </googleSearch>
+      <gitHub>
+        <projectId>RisingOak/jenkins-client</projectId>
+        <ribbonOrientation>right</ribbonOrientation>
+        <ribbonColor>gray</ribbonColor>
+      </gitHub>
+    </fluidoSkin>
+  </custom>
+  <body>
+    <menu name="Overview">
+      <item name="Introduction" href="index.html"/>
+    </menu>
+    <menu ref="reports" />
+  </body>
+</project>


### PR DESCRIPTION
can be published to GitHub
via gh-pages.

You can view an [example](http://khmarbaise.github.io/jenkins-client/) of the generated site which can be published by using:

`mvn site site:stage scm-publish:publish-scm `

The gh-pages branch must be exist first afterwards you can deploy the site via above command.
