### PR TITLE
Improved the integration test code.

### DIFF
--- a/src/test/java/com/offbytwo/jenkins/integration/BuildWithDetailsTest.java
+++ b/src/test/java/com/offbytwo/jenkins/integration/BuildWithDetailsTest.java
@@ -21,13 +21,14 @@ import hudson.model.FreeStyleProject;
 import hudson.model.ParametersAction;
 import hudson.model.StringParameterValue;
 
-public class BuildWithDetailsTest  {
+public class BuildWithDetailsTest {
 
     private final String JENKINS_WITH_DETAILS_TEST_JOB = "build_with_details";
+
     private JenkinsServer server;
+
     @Rule
     public JenkinsRule jenkinsRule = new JenkinsRule();
-
 
     @Before
     public void setUp() throws Exception {
@@ -38,13 +39,11 @@ public class BuildWithDetailsTest  {
 
     @Test
     public void checkCauses() throws Exception {
-        FreeStyleProject pr = jenkinsRule.getInstance().createProject(FreeStyleProject.class, JENKINS_WITH_DETAILS_TEST_JOB);
-        for (int i = 0; i < 5; i++)
-            pr.scheduleBuild(0, new Cause.UserIdCause(),
-                    new ParametersAction(new StringParameterValue("BUILD NUMBER", "" + i)));
+        FreeStyleProject pr = jenkinsRule.getInstance().createProject(FreeStyleProject.class,
+                JENKINS_WITH_DETAILS_TEST_JOB);
 
-        while (pr.isInQueue() || pr.isBuilding()) {
-        }
+        pr.scheduleBuild2(0, new Cause.UserIdCause(),
+                new ParametersAction(new StringParameterValue("BUILD NUMBER", "FirstBuild"))).get();
 
         JobWithDetails job = server.getJobs().get(JENKINS_WITH_DETAILS_TEST_JOB).details();
         BuildWithDetails build = job.getBuilds().get(0).details();

--- a/src/test/java/com/offbytwo/jenkins/integration/JenkinsServerIT.java
+++ b/src/test/java/com/offbytwo/jenkins/integration/JenkinsServerIT.java
@@ -69,10 +69,9 @@ public class JenkinsServerIT {
     @Test
     public void shouldReturnBuildStatusForBuild() throws Exception {
         FreeStyleProject pr = jenkinsRule.getInstance().createProject(FreeStyleProject.class, JENKINS_TEST_JOB);
-        pr.scheduleBuild(0, new Cause.UserIdCause(), new ParametersAction(new StringParameterValue("REVISION", "foobar")));
 
-        while (pr.isInQueue() || pr.isBuilding()) {
-        }
+        pr.scheduleBuild2(0, new Cause.UserIdCause(),
+                new ParametersAction(new StringParameterValue("REVISION", "foobar"))).get();
 
         JobWithDetails job = server.getJobs().get(JENKINS_TEST_JOB).details();
         BuildWithDetails build = job.getBuilds().get(0).details();
@@ -83,10 +82,9 @@ public class JenkinsServerIT {
     @Test
     public void shouldSupportBooleanParameters() throws Exception {
         FreeStyleProject pr = jenkinsRule.getInstance().createProject(FreeStyleProject.class, JENKINS_TEST_JOB);
-        pr.scheduleBuild(0, new Cause.UserIdCause(), new ParametersAction(new BooleanParameterValue("someValue", true)));
 
-        while (pr.isInQueue() || pr.isBuilding()) {
-        }
+        pr.scheduleBuild2(0, new Cause.UserIdCause(),
+                new ParametersAction(new BooleanParameterValue("someValue", true))).get();
 
         JobWithDetails job = server.getJobs().get(JENKINS_TEST_JOB).details();
         BuildWithDetails build = job.getBuilds().get(0).details();
@@ -173,12 +171,13 @@ public class JenkinsServerIT {
     public void testUpdateJob() throws Exception {
         final String description = "test-" + UUID.randomUUID().toString();
 
-        FreeStyleProject freeStyleProject = jenkinsRule.getInstance().createProject(FreeStyleProject.class, JENKINS_TEST_JOB);
+        FreeStyleProject freeStyleProject = jenkinsRule.getInstance().createProject(FreeStyleProject.class,
+                JENKINS_TEST_JOB);
         freeStyleProject.setDescription(description);
 
         String sourceXml = server.getJobXml(JENKINS_TEST_JOB);
-        String newXml = sourceXml.replaceAll("<description>.*</description>", "<description>" + description
-                + "</description>");
+        String newXml = sourceXml.replaceAll("<description>.*</description>",
+                "<description>" + description + "</description>");
         server.updateJob(JENKINS_TEST_JOB, newXml);
 
         String confirmXml = server.getJobXml(JENKINS_TEST_JOB);


### PR DESCRIPTION
Using scheduleBuild2(0,..).get() will return the resulting object incl. waiting for the end of the build which means no need for a while loop in the test cases to wait for the end of the scheduled builds.