### PR TITLE
invoke of build() should return the queue reference

### DIFF
--- a/src/main/java/com/offbytwo/jenkins/JenkinsServer.java
+++ b/src/main/java/com/offbytwo/jenkins/JenkinsServer.java
@@ -10,6 +10,7 @@ import com.google.common.base.Function;
 import com.google.common.collect.Maps;
 import com.google.common.net.UrlEscapers;
 import com.offbytwo.jenkins.client.JenkinsHttpClient;
+import com.offbytwo.jenkins.model.Build;
 import com.offbytwo.jenkins.model.Computer;
 import com.offbytwo.jenkins.model.ComputerSet;
 import com.offbytwo.jenkins.model.Job;
@@ -18,6 +19,8 @@ import com.offbytwo.jenkins.model.JobWithDetails;
 import com.offbytwo.jenkins.model.LabelWithDetails;
 import com.offbytwo.jenkins.model.MainView;
 import com.offbytwo.jenkins.model.MavenJobWithDetails;
+import com.offbytwo.jenkins.model.QueueItem;
+import com.offbytwo.jenkins.model.QueueReference;
 import com.offbytwo.jenkins.model.View;
 
 import org.apache.http.client.HttpResponseException;
@@ -349,5 +352,40 @@ public class JenkinsServer {
     private String encodeParam(String pathPart) {
         // jenkins doesn't like the + for space, use %20 instead
         return UrlEscapers.urlFormParameterEscaper().escape(pathPart);
+    }
+
+    public QueueItem getQueueItem(QueueReference ref) throws IOException 
+    {
+      try {
+        String url = ref.getQueueItemUrlPart();
+        // "/queue/item/" + id
+        QueueItem job = client.get(url , QueueItem.class);
+        job.setClient(client);
+
+        return job;
+      } catch (HttpResponseException e) {
+          if (e.getStatusCode() == 404) {
+              return null;
+          }
+          throw e;
+      }      
+    }
+
+    public Build getBuild(QueueItem q)  throws IOException 
+    {
+      // http://ci.seitenbau.net/job/rainer-ansible-build/51/
+      try {
+        String url = q.getExecutable().getUrl();
+        // "/queue/item/" + id
+        Build job = client.get(url , Build.class);
+        job.setClient(client);
+
+        return job;
+      } catch (HttpResponseException e) {
+          if (e.getStatusCode() == 404) {
+              return null;
+          }
+          throw e;
+      }      
     }
 }

--- a/src/main/java/com/offbytwo/jenkins/client/JenkinsHttpClient.java
+++ b/src/main/java/com/offbytwo/jenkins/client/JenkinsHttpClient.java
@@ -12,6 +12,8 @@ import com.offbytwo.jenkins.client.util.RequestReleasingInputStream;
 import com.offbytwo.jenkins.client.validator.HttpResponseValidator;
 import com.offbytwo.jenkins.model.BaseModel;
 import com.offbytwo.jenkins.model.Crumb;
+import com.offbytwo.jenkins.model.ExtractHeader;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.auth.AuthScope;
@@ -210,7 +212,15 @@ public class JenkinsHttpClient {
             httpResponseValidator.validateResponse(response);
 
             if (cls != null) {
-                return objectFromResponse(cls, response);
+                R responseObject; 
+                if(cls.equals(ExtractHeader.class) ) {
+                  ExtractHeader location = new ExtractHeader();
+                  location.setLocation(response.getFirstHeader("Location").getValue());
+                  responseObject = (R) location;
+                } else {
+                  responseObject = objectFromResponse(cls, response);
+                }
+                return responseObject;
             } else {
                 return null;
             }

--- a/src/main/java/com/offbytwo/jenkins/model/Executable.java
+++ b/src/main/java/com/offbytwo/jenkins/model/Executable.java
@@ -1,0 +1,25 @@
+package com.offbytwo.jenkins.model;
+
+public class Executable
+{
+  Long number;
+  String url;
+  public Long getNumber()
+  {
+    return number;
+  }
+  public void setNumber(Long number)
+  {
+    this.number = number;
+  }
+  public String getUrl()
+  {
+    return url;
+  }
+  public void setUrl(String url)
+  {
+    this.url = url;
+  }
+  
+  
+}

--- a/src/main/java/com/offbytwo/jenkins/model/ExtractHeader.java
+++ b/src/main/java/com/offbytwo/jenkins/model/ExtractHeader.java
@@ -1,0 +1,18 @@
+package com.offbytwo.jenkins.model;
+
+public class ExtractHeader extends BaseModel
+{
+
+  private String location;
+
+  public void setLocation(String value)
+  {
+    location=value;
+  }
+
+  public String getLocation()
+  {
+    return location;
+  }
+
+}

--- a/src/main/java/com/offbytwo/jenkins/model/Job.java
+++ b/src/main/java/com/offbytwo/jenkins/model/Job.java
@@ -70,9 +70,10 @@ public class Job extends BaseModel {
      * @param crumbFlag determines whether crumb flag is used
      * @throws IOException
      */
-    public void build(Map<String, String> params, boolean crumbFlag) throws IOException {
+    public QueueReference build(Map<String, String> params, boolean crumbFlag) throws IOException {
         String qs = join(Collections2.transform(params.entrySet(), new MapEntryToQueryStringPair()), "&");
-        client.post(url + "buildWithParameters?" + qs, null, null, crumbFlag);
+        ExtractHeader location = client.post(url + "buildWithParameters?" + qs, null, ExtractHeader.class, crumbFlag);
+        return new QueueReference(location.getLocation()); 
     }
 
     @Override

--- a/src/main/java/com/offbytwo/jenkins/model/QueueItem.java
+++ b/src/main/java/com/offbytwo/jenkins/model/QueueItem.java
@@ -1,0 +1,130 @@
+package com.offbytwo.jenkins.model;
+
+public class QueueItem extends BaseModel
+{
+  // actions
+
+  boolean blocked;
+
+  boolean buildable;
+
+  Long id;
+
+  Long inQueueSince;
+
+  String params;
+
+  boolean stuck;
+
+  // task
+
+  String url;
+
+  String why;
+
+  boolean cancelled;
+
+  Executable executable;
+
+  public boolean isBlocked()
+  {
+    return blocked;
+  }
+
+  public void setBlocked(boolean blocked)
+  {
+    this.blocked = blocked;
+  }
+
+  public boolean isBuildable()
+  {
+    return buildable;
+  }
+
+  public void setBuildable(boolean buildable)
+  {
+    this.buildable = buildable;
+  }
+
+  public Long getId()
+  {
+    return id;
+  }
+
+  public void setId(Long id)
+  {
+    this.id = id;
+  }
+
+  public Long getInQueueSince()
+  {
+    return inQueueSince;
+  }
+
+  public void setInQueueSince(Long inQueueSince)
+  {
+    this.inQueueSince = inQueueSince;
+  }
+
+  public String getParams()
+  {
+    return params;
+  }
+
+  public void setParams(String params)
+  {
+    this.params = params;
+  }
+
+  public boolean isStuck()
+  {
+    return stuck;
+  }
+
+  public void setStuck(boolean stuck)
+  {
+    this.stuck = stuck;
+  }
+
+  public String getUrl()
+  {
+    return url;
+  }
+
+  public void setUrl(String url)
+  {
+    this.url = url;
+  }
+
+  public String getWhy()
+  {
+    return why;
+  }
+
+  public void setWhy(String why)
+  {
+    this.why = why;
+  }
+
+  public boolean isCancelled()
+  {
+    return cancelled;
+  }
+
+  public void setCancelled(boolean cancelled)
+  {
+    this.cancelled = cancelled;
+  }
+
+  public Executable getExecutable()
+  {
+    return executable;
+  }
+
+  public void setExecutable(Executable executable)
+  {
+    this.executable = executable;
+  }
+
+  
+}

--- a/src/main/java/com/offbytwo/jenkins/model/QueueReference.java
+++ b/src/main/java/com/offbytwo/jenkins/model/QueueReference.java
@@ -1,0 +1,19 @@
+package com.offbytwo.jenkins.model;
+
+public class QueueReference extends BaseModel  
+{
+
+  private String queueItem;
+
+  public QueueReference(String location)
+  {
+    queueItem = location;
+  }
+
+  public String getQueueItemUrlPart()
+  {
+    return queueItem;
+  }
+ 
+
+}


### PR DESCRIPTION
The build methods should return a queue reference, so when triggering an build the invoker can track the build. Currently the lib does not provide a way to do this.

#####  Background:
When triggering an jenkins build, the buildnumber is null. This is a feature : https://issues.jenkins-ci.org/browse/JENKINS-12827 . but the Location header points to the queue Item.

##### Questions / limit of (initial) pull request:
 
1. I'm not sure if the way the Location Header is extracted is ok, or if this should be done in an other way.
2. The /queue/* api had to be added. The models and api is not completed.

##### Peudo code to use this for build tracking:

  QueueReference ref = job.build(params,false);
  while(getQueueItem(ref).getExecutable()==null) { sleep() }
  while(jenkins.getBuild(q).details().isBuilding()) { sleep() }
  // build done