### PR TITLE
 #39: Don't propagate IOException when GET for /CrumbIssuer fails.

### DIFF
--- a/src/main/java/com/offbytwo/jenkins/client/JenkinsHttpClient.java
+++ b/src/main/java/com/offbytwo/jenkins/client/JenkinsHttpClient.java
@@ -165,6 +165,26 @@ public class JenkinsHttpClient {
     }
 
     /**
+     * Perform a GET request and parse the response to the given class,
+     * logging any IOException that is thrown rather than propagating it.
+     *
+     * @param path path to request, can be relative or absolute
+     * @param cls class of the response
+     * @param <T> type of the response
+     * @return an instance of the supplied class
+     */
+    public <T extends BaseModel> T getQuietly(String path, Class<T> cls) {
+        T value;
+        try {
+            value = get(path, cls);
+            return value;
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    /**
      * Perform a GET request and return the response as InputStream
      *
      * @param path path to request, can be relative or absolute
@@ -196,7 +216,7 @@ public class JenkinsHttpClient {
     public <R extends BaseModel, D> R post(String path, D data, Class<R> cls, boolean crumbFlag) throws IOException {
         HttpPost request = new HttpPost(api(path));
         if (crumbFlag == true) {
-            Crumb crumb = get("/crumbIssuer", Crumb.class);
+            Crumb crumb = getQuietly("/crumbIssuer", Crumb.class);
             if (crumb != null) {
                 request.addHeader(new BasicHeader(crumb.getCrumbRequestField(), crumb.getCrumb()));
             }
@@ -246,7 +266,7 @@ public class JenkinsHttpClient {
     public String post_xml(String path, String xml_data, boolean crumbFlag) throws IOException {
         HttpPost request = new HttpPost(api(path));
         if (crumbFlag == true) {
-            Crumb crumb = get("/crumbIssuer", Crumb.class);
+            Crumb crumb = getQuietly("/crumbIssuer", Crumb.class);
             if (crumb != null) {
                 request.addHeader(new BasicHeader(crumb.getCrumbRequestField(), crumb.getCrumb()));
             }


### PR DESCRIPTION
Squashed the commits in #110 