### PR TITLE
Making job name case sensitive

### DIFF
--- a/src/main/java/com/offbytwo/jenkins/JenkinsServer.java
+++ b/src/main/java/com/offbytwo/jenkins/JenkinsServer.java
@@ -146,7 +146,7 @@ public class JenkinsServer {
             @Override
             public String apply(Job job) {
                 job.setClient(client);
-                return job.getName().toLowerCase();
+                return job.getName();
             }
         });
     }

--- a/src/main/java/com/offbytwo/jenkins/model/FolderJob.java
+++ b/src/main/java/com/offbytwo/jenkins/model/FolderJob.java
@@ -49,7 +49,7 @@ public class FolderJob extends Job {
             @Override
             public String apply(Job job) {
                 job.setClient(client);
-                return job.getName().toLowerCase();
+                return job.getName();
             }
         });
     }
@@ -65,7 +65,7 @@ public class FolderJob extends Job {
             @Override
             public String apply(Job job) {
                 job.setClient(client);
-                return job.getName().toLowerCase();
+                return job.getName();
             }
         }).get(name);
     }

--- a/src/test/java/com/offbytwo/jenkins/JenkinsServerTest.java
+++ b/src/test/java/com/offbytwo/jenkins/JenkinsServerTest.java
@@ -17,11 +17,12 @@ import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
 import org.apache.http.entity.ContentType;
-import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -38,26 +39,41 @@ public class JenkinsServerTest extends BaseUnitTest {
 
     private JenkinsHttpClient client = mock(JenkinsHttpClient.class);
     private JenkinsServer server = new JenkinsServer(client);
-    private MainView mainView = new MainView(new Job("Hello", "http://localhost/job/Hello/"));
 
     public JenkinsServerTest() throws Exception {
     }
 
-    @Before
-    public void setUp() throws Exception {
+    @Test
+    public void testReturnSingleJob() throws Exception {
+        shouldReturnListOfJobs("hello");
+    }
+
+    @Test
+    public void testReturnListOfJobs() throws Exception {
+        shouldReturnListOfJobs("hello", "Hello", "HeLLo");
+    }
+
+    private void shouldReturnListOfJobs(String...jobNames) throws Exception {
+        MainView mainView = createTestView("http://localhost/job/", jobNames);
         given(client.get("/", MainView.class)).willReturn(mainView);
+        Map<String, Job> jobs = server.getJobs();
+        for(String name : jobNames)
+            assertTrue(jobs.containsKey(name));
+
+        assertEquals(jobNames.length, jobs.size());
     }
 
     @Test
-    public void shouldReturnListOfJobs() throws Exception {
-        assertTrue(server.getJobs().containsKey("Hello"));
+    public void testGetJobXmls() throws Exception {
+        shouldGetJobXml("pr");
+        shouldGetJobXml("hello");
+        shouldGetJobXml("Hello");
+        shouldGetJobXml("HeLLo");
     }
 
-    @Test
-    public void testGetJobXml() throws Exception {
+    private void shouldGetJobXml(String jobName) throws Exception {
         // given
         String xmlString = "<xml>some xml goes here</xml>";
-        String jobName = "pr";
 
         given(client.get(anyString())).willReturn(xmlString);
 
@@ -65,19 +81,28 @@ public class JenkinsServerTest extends BaseUnitTest {
         String xmlReturn = server.getJobXml(jobName);
 
         // then
-        verify(client).get("/job/pr/config.xml");
+        verify(client).get("/job/"+jobName+"/config.xml");
         assertEquals(xmlString, xmlReturn);
     }
 
     @Test
-    public void testFolderGetJobs() throws Exception {
+    public void testFolderGetSingleJob() throws Exception {
+        shouldGetFolderJobs("jobname");
+    }
+
+    @Test
+    public void testFolderGetMultipleJobs() throws Exception {
+        shouldGetFolderJobs("hello", "Hello", "HeLLo");
+    }
+
+    private void shouldGetFolderJobs(String... jobNames) throws IOException {
         // given
         String path = "http://localhost/jobs/someFolder/";
-        Job someJob = new Job("jobname", path + "jobname");
         FolderJob folderJob = new FolderJob("someFolder", path);
-        MainView mv = new MainView();
-        mv.setJobs(ImmutableList.of(someJob));
-        
+
+        List<Job> someJobs = createTestJobs(path, jobNames);
+        MainView mv = createTestView(someJobs);
+
         given(client.get(eq(path), eq(MainView.class))).willReturn(mv);
         
         // when
@@ -85,7 +110,11 @@ public class JenkinsServerTest extends BaseUnitTest {
         
         // then
         verify(client).get(path, MainView.class);
-        assertEquals(someJob, map.get("jobname"));
+
+        for(String name : jobNames)
+            assertTrue(someJobs.contains(map.get(name)));
+
+        assertEquals(jobNames.length, map.size());
     }
     
     @Test
@@ -252,5 +281,22 @@ public class JenkinsServerTest extends BaseUnitTest {
         given(client.get("/job/encoded%2Fproperly%3F/config.xml")).willReturn("<xml>not a real response</xml>");
 
         assertEquals("<xml>not a real response</xml>", server.getJobXml("encoded/properly?"));
+    }
+
+    private MainView createTestView(List<Job> jobs) {
+        return new MainView(jobs.toArray(new Job[0]));
+    }
+
+    private MainView createTestView(String baseUrl, String... jobNames) {
+        return createTestView(createTestJobs(baseUrl, jobNames));
+    }
+
+    private List<Job> createTestJobs(String baseUrl, String... jobNames) {
+        List<Job> jobs = new ArrayList<Job>();
+        for(String name: jobNames) {
+            jobs.add(new Job(name, baseUrl+name));
+        }
+
+        return jobs;
     }
 }

--- a/src/test/java/com/offbytwo/jenkins/JenkinsServerTest.java
+++ b/src/test/java/com/offbytwo/jenkins/JenkinsServerTest.java
@@ -50,7 +50,7 @@ public class JenkinsServerTest extends BaseUnitTest {
 
     @Test
     public void shouldReturnListOfJobs() throws Exception {
-        assertTrue(server.getJobs().containsKey("hello"));
+        assertTrue(server.getJobs().containsKey("Hello"));
     }
 
     @Test


### PR DESCRIPTION
This patch makes job name case sensitive, and those it's allowing to have multiple jobs with same name that differs with upper/lower case - as it's possible to setup it like this in Jenkins.